### PR TITLE
Default indicators & default subfields

### DIFF
--- a/src/schema/field-010.schema.json
+++ b/src/schema/field-010.schema.json
@@ -8,6 +8,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"
@@ -18,6 +19,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"

--- a/src/schema/field-010.schema.json
+++ b/src/schema/field-010.schema.json
@@ -31,6 +31,9 @@
       "minItems": 1,
       "items": {
         "type": "object",
+        "defaultProperties": [
+          "a"
+        ],
         "properties": {
           "8": {
             "title": "Field link and sequence number",

--- a/src/schema/field-011.schema.json
+++ b/src/schema/field-011.schema.json
@@ -8,6 +8,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"
@@ -18,6 +19,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"

--- a/src/schema/field-011.schema.json
+++ b/src/schema/field-011.schema.json
@@ -31,6 +31,9 @@
       "minItems": 1,
       "items": {
         "type": "object",
+        "defaultProperties": [
+          "a"
+        ],
         "properties": {
           "a": {
             "title": "LINKING LC control number",

--- a/src/schema/field-013.schema.json
+++ b/src/schema/field-013.schema.json
@@ -33,6 +33,9 @@
         "minItems": 1,
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-013.schema.json
+++ b/src/schema/field-013.schema.json
@@ -10,6 +10,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -20,6 +21,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-015.schema.json
+++ b/src/schema/field-015.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "2": {
               "title": "Source",

--- a/src/schema/field-015.schema.json
+++ b/src/schema/field-015.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-016.schema.json
+++ b/src/schema/field-016.schema.json
@@ -37,6 +37,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "2": {
               "title": "Source",

--- a/src/schema/field-016.schema.json
+++ b/src/schema/field-016.schema.json
@@ -12,6 +12,7 @@
           "\\",
           "7"
         ],
+        "defaultValue": "\\",
         "code": {
           "7": {
             "title": "Agency identified in subfield $2"
@@ -25,6 +26,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-017.schema.json
+++ b/src/schema/field-017.schema.json
@@ -13,6 +13,7 @@
           "1",
           "2"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "United States [OBSOLETE]"
@@ -29,6 +30,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-017.schema.json
+++ b/src/schema/field-017.schema.json
@@ -41,6 +41,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "2": {
               "title": "Source",

--- a/src/schema/field-018.schema.json
+++ b/src/schema/field-018.schema.json
@@ -8,6 +8,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"
@@ -18,6 +19,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"

--- a/src/schema/field-018.schema.json
+++ b/src/schema/field-018.schema.json
@@ -30,6 +30,9 @@
       "type": "array",
       "items": {
         "type": "object",
+        "defaultProperties": [
+          "a"
+        ],
         "properties": {
           "6": {
             "title": "Linkage",

--- a/src/schema/field-020.schema.json
+++ b/src/schema/field-020.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-020.schema.json
+++ b/src/schema/field-020.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-022-register.schema.json
+++ b/src/schema/field-022-register.schema.json
@@ -12,6 +12,7 @@
         "0",
         "1"
       ],
+      "defaultValue": "\\",
       "code": {
         "0": {
           "title": "Serial of international interest"
@@ -28,6 +29,7 @@
       "title": "Nonfiling characters",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Obsolete: use NSB / NSE / pipe character instead"

--- a/src/schema/field-022-register.schema.json
+++ b/src/schema/field-022-register.schema.json
@@ -40,6 +40,9 @@
       "type": "array",
       "items": {
         "type": "object",
+        "defaultProperties": [
+          "a"
+        ],
         "properties": {
           "0": {
             "title": "Authority record control number or standard number",

--- a/src/schema/field-022-work.schema.json
+++ b/src/schema/field-022-work.schema.json
@@ -12,6 +12,7 @@
         "0",
         "1"
       ],
+      "defaultValue": "\\",
       "code": {
         "0": {
           "title": "Serial of international interest"
@@ -28,6 +29,7 @@
       "title": "Nonfiling characters",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Obsolete: use NSB / NSE / pipe character instead"

--- a/src/schema/field-022-work.schema.json
+++ b/src/schema/field-022-work.schema.json
@@ -40,6 +40,9 @@
       "type": "array",
       "items": {
         "type": "object",
+        "defaultProperties": [
+          "a"
+        ],
         "properties": {
           "0": {
             "title": "Authority record control number or standard number",

--- a/src/schema/field-024.schema.json
+++ b/src/schema/field-024.schema.json
@@ -67,6 +67,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "2": {
               "title": "Source of number or code",

--- a/src/schema/field-024.schema.json
+++ b/src/schema/field-024.schema.json
@@ -17,6 +17,7 @@
           "7",
           "8"
         ],
+        "defaultValue": "8",
         "code": {
           "0": {
             "title": "International Standard Recording Code (ISRC)"
@@ -49,6 +50,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "No difference"

--- a/src/schema/field-025.schema.json
+++ b/src/schema/field-025.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-025.schema.json
+++ b/src/schema/field-025.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "8": {
               "title": "Field link and sequence number",

--- a/src/schema/field-026.schema.json
+++ b/src/schema/field-026.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "2": {
               "title": "Source",

--- a/src/schema/field-026.schema.json
+++ b/src/schema/field-026.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-027.schema.json
+++ b/src/schema/field-027.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-027.schema.json
+++ b/src/schema/field-027.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-028.schema.json
+++ b/src/schema/field-028.schema.json
@@ -17,6 +17,7 @@
           "5",
           "6"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Issue number"
@@ -50,6 +51,7 @@
           "2",
           "3"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "No note, no added entry"

--- a/src/schema/field-028.schema.json
+++ b/src/schema/field-028.schema.json
@@ -71,6 +71,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-030.schema.json
+++ b/src/schema/field-030.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-030.schema.json
+++ b/src/schema/field-030.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-031.schema.json
+++ b/src/schema/field-031.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "2": {
               "title": "System code",

--- a/src/schema/field-031.schema.json
+++ b/src/schema/field-031.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-032.schema.json
+++ b/src/schema/field-032.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-032.schema.json
+++ b/src/schema/field-032.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-033.schema.json
+++ b/src/schema/field-033.schema.json
@@ -59,6 +59,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-033.schema.json
+++ b/src/schema/field-033.schema.json
@@ -14,6 +14,7 @@
           "1",
           "2"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Single date"
@@ -38,6 +39,7 @@
           "1",
           "2"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Capture"

--- a/src/schema/field-034.schema.json
+++ b/src/schema/field-034.schema.json
@@ -51,6 +51,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-034.schema.json
+++ b/src/schema/field-034.schema.json
@@ -13,6 +13,7 @@
           "1",
           "3"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Scale indeterminable/No scale recorded"
@@ -33,6 +34,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Outer ring"

--- a/src/schema/field-035.schema.json
+++ b/src/schema/field-035.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-035.schema.json
+++ b/src/schema/field-035.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-036.schema.json
+++ b/src/schema/field-036.schema.json
@@ -8,6 +8,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"
@@ -18,6 +19,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"

--- a/src/schema/field-036.schema.json
+++ b/src/schema/field-036.schema.json
@@ -30,6 +30,12 @@
       "type": "array",
       "items": {
         "type": "object",
+        "defaultProperties": [
+          "a"
+        ],
+        "defaultProperties": [
+          "a"
+        ],
         "properties": {
           "6": {
             "title": "Linkage",

--- a/src/schema/field-037.schema.json
+++ b/src/schema/field-037.schema.json
@@ -41,6 +41,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "3": {
               "title": "Materials specified",

--- a/src/schema/field-037.schema.json
+++ b/src/schema/field-037.schema.json
@@ -13,6 +13,7 @@
           "2",
           "3"
         ],
+        "defaultValue": "\\",
         "code": {
           "2": {
             "title": "Intervening"
@@ -29,6 +30,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-038.schema.json
+++ b/src/schema/field-038.schema.json
@@ -8,6 +8,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"
@@ -18,6 +19,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"

--- a/src/schema/field-038.schema.json
+++ b/src/schema/field-038.schema.json
@@ -30,6 +30,12 @@
       "type": "array",
       "items": {
         "type": "object",
+        "defaultProperties": [
+          "a"
+        ],
+        "defaultProperties": [
+          "a"
+        ],
         "properties": {
           "6": {
             "title": "Linkage",

--- a/src/schema/field-040.schema.json
+++ b/src/schema/field-040.schema.json
@@ -8,6 +8,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"
@@ -18,6 +19,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"

--- a/src/schema/field-040.schema.json
+++ b/src/schema/field-040.schema.json
@@ -30,6 +30,12 @@
       "type": "array",
       "items": {
         "type": "object",
+        "defaultProperties": [
+          "a"
+        ],
+        "defaultProperties": [
+          "a"
+        ],
         "properties": {
           "6": {
             "title": "Linkage",

--- a/src/schema/field-041.schema.json
+++ b/src/schema/field-041.schema.json
@@ -13,6 +13,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Item not a translation/does not include a translation"
@@ -32,6 +33,7 @@
           "\\",
           "7"
         ],
+        "defaultValue": "\\",
         "code": {
           "7": {
             "title": "Source specified in subfield $2"

--- a/src/schema/field-041.schema.json
+++ b/src/schema/field-041.schema.json
@@ -47,6 +47,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "2": {
               "title": "Source of code",

--- a/src/schema/field-042.schema.json
+++ b/src/schema/field-042.schema.json
@@ -8,6 +8,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"
@@ -18,6 +19,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"

--- a/src/schema/field-042.schema.json
+++ b/src/schema/field-042.schema.json
@@ -30,6 +30,12 @@
       "type": "array",
       "items": {
         "type": "object",
+        "defaultProperties": [
+          "a"
+        ],
+        "defaultProperties": [
+          "a"
+        ],
         "properties": {
           "a": {
             "title": "Authentication code",

--- a/src/schema/field-043.schema.json
+++ b/src/schema/field-043.schema.json
@@ -8,6 +8,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"
@@ -18,6 +19,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"

--- a/src/schema/field-043.schema.json
+++ b/src/schema/field-043.schema.json
@@ -30,6 +30,9 @@
       "type": "array",
       "items": {
         "type": "object",
+        "defaultProperties": [
+          "a"
+        ],
         "properties": {
           "0": {
             "title": "Authority record control number or standard number",

--- a/src/schema/field-044.schema.json
+++ b/src/schema/field-044.schema.json
@@ -30,6 +30,9 @@
       "type": "array",
       "items": {
         "type": "object",
+        "defaultProperties": [
+          "a"
+        ],
         "properties": {
           "2": {
             "title": "Source of local subentity code",

--- a/src/schema/field-044.schema.json
+++ b/src/schema/field-044.schema.json
@@ -8,6 +8,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"
@@ -18,6 +19,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"

--- a/src/schema/field-045.schema.json
+++ b/src/schema/field-045.schema.json
@@ -44,6 +44,9 @@
       "type": "array",
       "items": {
         "type": "object",
+        "defaultProperties": [
+          "a"
+        ],
         "properties": {
           "6": {
             "title": "Linkage",

--- a/src/schema/field-045.schema.json
+++ b/src/schema/field-045.schema.json
@@ -13,6 +13,7 @@
         "1",
         "2"
       ],
+      "defaultValue": "\\",
       "code": {
         "0": {
           "title": "Single date/time"
@@ -32,6 +33,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"

--- a/src/schema/field-046.schema.json
+++ b/src/schema/field-046.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "2": {
               "title": "Source of date",

--- a/src/schema/field-046.schema.json
+++ b/src/schema/field-046.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-047.schema.json
+++ b/src/schema/field-047.schema.json
@@ -37,6 +37,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "2": {
               "title": "Source of code",

--- a/src/schema/field-047.schema.json
+++ b/src/schema/field-047.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -22,6 +23,7 @@
           "\\",
           "7"
         ],
+        "defaultValue": "\\",
         "code": {
           "7": {
             "title": "Source specified in subfield $2"

--- a/src/schema/field-048.schema.json
+++ b/src/schema/field-048.schema.json
@@ -37,6 +37,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "2": {
               "title": "Source of code",

--- a/src/schema/field-048.schema.json
+++ b/src/schema/field-048.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -22,6 +23,7 @@
           "\\",
           "7"
         ],
+        "defaultValue": "\\",
         "code": {
           "7": {
             "title": "Source specified in subfield $2"

--- a/src/schema/field-050.schema.json
+++ b/src/schema/field-050.schema.json
@@ -51,6 +51,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-050.schema.json
+++ b/src/schema/field-050.schema.json
@@ -13,6 +13,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Item is in LC"
@@ -33,6 +34,7 @@
           "0",
           "4"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Assigned by LC"

--- a/src/schema/field-051.schema.json
+++ b/src/schema/field-051.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-051.schema.json
+++ b/src/schema/field-051.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "8": {
               "title": "Field link and sequence number",

--- a/src/schema/field-052.schema.json
+++ b/src/schema/field-052.schema.json
@@ -45,6 +45,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-052.schema.json
+++ b/src/schema/field-052.schema.json
@@ -14,6 +14,7 @@
           "1",
           "7"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "U.S. Dept. of Defense Classification [OBSOLETE]"
@@ -33,6 +34,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-055.schema.json
+++ b/src/schema/field-055.schema.json
@@ -79,6 +79,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-055.schema.json
+++ b/src/schema/field-055.schema.json
@@ -13,6 +13,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Work held by LAC"
@@ -40,6 +41,7 @@
           "8",
           "9"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "LC"

--- a/src/schema/field-060.schema.json
+++ b/src/schema/field-060.schema.json
@@ -51,6 +51,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-060.schema.json
+++ b/src/schema/field-060.schema.json
@@ -13,6 +13,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Item is in NLM"
@@ -33,6 +34,7 @@
           "0",
           "4"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Assigned by NLM"

--- a/src/schema/field-061.schema.json
+++ b/src/schema/field-061.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-061.schema.json
+++ b/src/schema/field-061.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "8": {
               "title": "Field link and sequence number",

--- a/src/schema/field-066.schema.json
+++ b/src/schema/field-066.schema.json
@@ -8,6 +8,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"
@@ -18,6 +19,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"

--- a/src/schema/field-066.schema.json
+++ b/src/schema/field-066.schema.json
@@ -30,6 +30,9 @@
       "type": "array",
       "items": {
         "type": "object",
+        "defaultProperties": [
+          "a"
+        ],
         "properties": {
           "a": {
             "title": "Primary G0 character set",

--- a/src/schema/field-070.schema.json
+++ b/src/schema/field-070.schema.json
@@ -13,6 +13,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Item is in NAL"
@@ -29,6 +30,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-070.schema.json
+++ b/src/schema/field-070.schema.json
@@ -41,6 +41,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-071.schema.json
+++ b/src/schema/field-071.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-071.schema.json
+++ b/src/schema/field-071.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "8": {
               "title": "Field link and sequence number",

--- a/src/schema/field-072.schema.json
+++ b/src/schema/field-072.schema.json
@@ -37,6 +37,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "2": {
               "title": "Source",

--- a/src/schema/field-072.schema.json
+++ b/src/schema/field-072.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -22,6 +23,7 @@
           "0",
           "7"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "NAL subject category code list"

--- a/src/schema/field-074.schema.json
+++ b/src/schema/field-074.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-074.schema.json
+++ b/src/schema/field-074.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "8": {
               "title": "Field link and sequence number",

--- a/src/schema/field-080-register.schema.json
+++ b/src/schema/field-080-register.schema.json
@@ -13,6 +13,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "0",
         "code": {
           "0": {
             "title": "Full"
@@ -29,6 +30,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-080-register.schema.json
+++ b/src/schema/field-080-register.schema.json
@@ -41,6 +41,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a",
+            "2"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-080-work.schema.json
+++ b/src/schema/field-080-work.schema.json
@@ -13,6 +13,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "0",
         "code": {
           "0": {
             "title": "Full"
@@ -29,6 +30,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-080-work.schema.json
+++ b/src/schema/field-080-work.schema.json
@@ -41,6 +41,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a",
+            "2"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-082-register.schema.json
+++ b/src/schema/field-082-register.schema.json
@@ -15,6 +15,7 @@
           "2",
           "7"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Full edition"
@@ -41,6 +42,7 @@
           "0",
           "4"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Assigned by LC"

--- a/src/schema/field-082-register.schema.json
+++ b/src/schema/field-082-register.schema.json
@@ -59,6 +59,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a",
+            "2"
+          ],
           "properties": {
             "2": {
               "title": "Edition number",

--- a/src/schema/field-082-work.schema.json
+++ b/src/schema/field-082-work.schema.json
@@ -15,6 +15,7 @@
           "2",
           "7"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Full edition"
@@ -41,6 +42,7 @@
           "0",
           "4"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Assigned by LC"

--- a/src/schema/field-082-work.schema.json
+++ b/src/schema/field-082-work.schema.json
@@ -59,6 +59,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a",
+            "2"
+          ],
           "properties": {
             "2": {
               "title": "Edition number",

--- a/src/schema/field-083.schema.json
+++ b/src/schema/field-083.schema.json
@@ -13,6 +13,7 @@
           "1",
           "7"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Full edition"
@@ -29,6 +30,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-083.schema.json
+++ b/src/schema/field-083.schema.json
@@ -41,6 +41,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "2": {
               "title": "Edition number",

--- a/src/schema/field-084.schema.json
+++ b/src/schema/field-084.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-084.schema.json
+++ b/src/schema/field-084.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-085.schema.json
+++ b/src/schema/field-085.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-085.schema.json
+++ b/src/schema/field-085.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-086.schema.json
+++ b/src/schema/field-086.schema.json
@@ -13,6 +13,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Superintendent of Documents Classification System"
@@ -28,6 +29,7 @@
       "indicator2": {
         "title": "Government jurisdiction (BK MP MU VM SE) [OBSOLETE]",
         "type": "string",
+        "defaultValue": "\\",
         "code": {}
       },
       "subFields": {

--- a/src/schema/field-086.schema.json
+++ b/src/schema/field-086.schema.json
@@ -36,6 +36,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-088.schema.json
+++ b/src/schema/field-088.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-088.schema.json
+++ b/src/schema/field-088.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-100.schema.json
+++ b/src/schema/field-100.schema.json
@@ -13,6 +13,7 @@
         "2",
         "3"
       ],
+      "defaultValue": "\\",
       "code": {
         "0": {
           "title": "Forename"
@@ -32,6 +33,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"

--- a/src/schema/field-100.schema.json
+++ b/src/schema/field-100.schema.json
@@ -44,6 +44,9 @@
       "type": "array",
       "items": {
         "type": "object",
+        "defaultProperties": [
+          "a"
+        ],
         "properties": {
           "0": {
             "title": "Authority record control number or standard number",

--- a/src/schema/field-110.schema.json
+++ b/src/schema/field-110.schema.json
@@ -40,6 +40,9 @@
       "type": "array",
       "items": {
         "type": "object",
+        "defaultProperties": [
+          "a"
+        ],
         "properties": {
           "0": {
             "title": "Authority record control number or standard number",

--- a/src/schema/field-110.schema.json
+++ b/src/schema/field-110.schema.json
@@ -12,6 +12,7 @@
         "1",
         "2"
       ],
+      "defaultValue": "\\",
       "code": {
         "0": {
           "title": "Inverted name"
@@ -28,6 +29,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"

--- a/src/schema/field-111.schema.json
+++ b/src/schema/field-111.schema.json
@@ -40,6 +40,9 @@
       "type": "array",
       "items": {
         "type": "object",
+        "defaultProperties": [
+          "a"
+        ],
         "properties": {
           "0": {
             "title": "Authority record control number or standard number",

--- a/src/schema/field-111.schema.json
+++ b/src/schema/field-111.schema.json
@@ -12,6 +12,7 @@
         "1",
         "2"
       ],
+      "defaultValue": "\\",
       "code": {
         "0": {
           "title": "Inverted name"
@@ -28,6 +29,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"

--- a/src/schema/field-130.schema.json
+++ b/src/schema/field-130.schema.json
@@ -11,6 +11,7 @@
         "0",
         "\\"
       ],
+      "defaultValue": "\\",
       "code": {
         "0": {
           "title": "9"
@@ -24,6 +25,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"

--- a/src/schema/field-130.schema.json
+++ b/src/schema/field-130.schema.json
@@ -36,6 +36,9 @@
       "type": "array",
       "items": {
         "type": "object",
+        "defaultProperties": [
+          "a"
+        ],
         "properties": {
           "0": {
             "title": "Authority record control number or standard number",

--- a/src/schema/field-210-register.schema.json
+++ b/src/schema/field-210-register.schema.json
@@ -12,6 +12,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "1",
         "code": {
           "0": {
             "title": "No added entry"
@@ -28,6 +29,7 @@
           "\\",
           "0"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Other abbreviated title"

--- a/src/schema/field-210-register.schema.json
+++ b/src/schema/field-210-register.schema.json
@@ -43,6 +43,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a",
+            "b"
+          ],
           "properties": {
             "2": {
               "title": "Source",

--- a/src/schema/field-210-work.schema.json
+++ b/src/schema/field-210-work.schema.json
@@ -12,6 +12,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "1",
         "code": {
           "0": {
             "title": "No added entry"
@@ -28,6 +29,7 @@
           "\\",
           "0"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Other abbreviated title"

--- a/src/schema/field-210-work.schema.json
+++ b/src/schema/field-210-work.schema.json
@@ -43,6 +43,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a",
+            "b"
+          ],
           "properties": {
             "2": {
               "title": "Source",

--- a/src/schema/field-211.schema.json
+++ b/src/schema/field-211.schema.json
@@ -37,6 +37,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-211.schema.json
+++ b/src/schema/field-211.schema.json
@@ -12,6 +12,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "No title added entry"
@@ -25,6 +26,7 @@
         "title": "Nonfiling characters",
         "type": "string",
         "const": "0",
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "9"

--- a/src/schema/field-212.schema.json
+++ b/src/schema/field-212.schema.json
@@ -37,6 +37,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-212.schema.json
+++ b/src/schema/field-212.schema.json
@@ -12,6 +12,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "No title added entry"
@@ -25,6 +26,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-214.schema.json
+++ b/src/schema/field-214.schema.json
@@ -37,6 +37,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-214.schema.json
+++ b/src/schema/field-214.schema.json
@@ -12,6 +12,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "No title added entry"
@@ -25,6 +26,7 @@
         "title": "Nonfiling characters",
         "type": "string",
         "const": "0",
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "9"

--- a/src/schema/field-222.schema.json
+++ b/src/schema/field-222.schema.json
@@ -8,6 +8,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"
@@ -18,6 +19,7 @@
       "title": "Nonfiling characters",
       "type": "string",
       "pattern": "[0-9]|\\\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "NSB / NSE characters"

--- a/src/schema/field-222.schema.json
+++ b/src/schema/field-222.schema.json
@@ -36,6 +36,10 @@
       "type": "array",
       "items": {
         "type": "object",
+        "defaultProperties": [
+          "a",
+          "b"
+        ],
         "properties": {
           "6": {
             "title": "Linkage",

--- a/src/schema/field-240.schema.json
+++ b/src/schema/field-240.schema.json
@@ -13,6 +13,7 @@
         "2",
         "3"
       ],
+      "defaultValue": "\\",
       "code": {
         "0": {
           "title": "Not printed or displayed"
@@ -32,6 +33,7 @@
       "title": "Nonfiling characters",
       "type": "string",
       "const": "0",
+      "defaultValue": "\\",
       "code": {
         "0": {
           "title": "9"

--- a/src/schema/field-240.schema.json
+++ b/src/schema/field-240.schema.json
@@ -44,6 +44,9 @@
       "type": "array",
       "items": {
         "type": "object",
+        "defaultProperties": [
+          "a"
+        ],
         "properties": {
           "0": {
             "title": "Authority record control number or standard number",

--- a/src/schema/field-241.schema.json
+++ b/src/schema/field-241.schema.json
@@ -36,6 +36,9 @@
       "type": "array",
       "items": {
         "type": "object",
+        "defaultProperties": [
+          "a"
+        ],
         "properties": {
           "a": {
             "title": "Romanized title",

--- a/src/schema/field-241.schema.json
+++ b/src/schema/field-241.schema.json
@@ -11,6 +11,7 @@
         "0",
         "1"
       ],
+      "defaultValue": "\\",
       "code": {
         "0": {
           "title": "No title added entry"
@@ -24,6 +25,7 @@
       "title": "Nonfiling characters",
       "type": "string",
       "const": "0",
+      "defaultValue": "\\",
       "code": {
         "0": {
           "title": "9"

--- a/src/schema/field-242.schema.json
+++ b/src/schema/field-242.schema.json
@@ -37,6 +37,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-242.schema.json
+++ b/src/schema/field-242.schema.json
@@ -12,6 +12,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "No added entry"
@@ -25,6 +26,7 @@
         "title": "Nonfiling characters",
         "type": "string",
         "const": "0",
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "9"

--- a/src/schema/field-243.schema.json
+++ b/src/schema/field-243.schema.json
@@ -44,6 +44,9 @@
       "type": "array",
       "items": {
         "type": "object",
+        "defaultProperties": [
+          "a"
+        ],
         "properties": {
           "6": {
             "title": "Linkage",

--- a/src/schema/field-243.schema.json
+++ b/src/schema/field-243.schema.json
@@ -13,6 +13,7 @@
         "2",
         "3"
       ],
+      "defaultValue": "\\",
       "code": {
         "0": {
           "title": "Not printed or displayed"
@@ -32,6 +33,7 @@
       "title": "Nonfiling characters",
       "type": "string",
       "const": "0",
+      "defaultValue": "\\",
       "code": {
         "0": {
           "title": "9"

--- a/src/schema/field-245.schema.json
+++ b/src/schema/field-245.schema.json
@@ -42,6 +42,9 @@
       "type": "array",
       "items": {
         "type": "object",
+        "defaultProperties": [
+          "a"
+        ],
         "properties": {
           "6": {
             "title": "Linkage",

--- a/src/schema/field-245.schema.json
+++ b/src/schema/field-245.schema.json
@@ -11,6 +11,7 @@
         "0",
         "1"
       ],
+      "defaultValue": "1",
       "code": {
         "0": {
           "title": "No added entry"
@@ -24,6 +25,7 @@
       "title": "Nonfiling characters",
       "type": "string",
       "pattern": "[0-9]|\\\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "NSB / NSE characters"

--- a/src/schema/field-246.schema.json
+++ b/src/schema/field-246.schema.json
@@ -83,6 +83,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "5": {
               "title": "Institution to which field applies",

--- a/src/schema/field-246.schema.json
+++ b/src/schema/field-246.schema.json
@@ -14,6 +14,7 @@
           "2",
           "3"
         ],
+        "defaultValue": "3",
         "code": {
           "0": {
             "title": "Note, no added entry"
@@ -44,6 +45,7 @@
           "7",
           "8"
         ],
+        "defaultValue": "3",
         "code": {
           "0": {
             "title": "Portion of title"

--- a/src/schema/field-247.schema.json
+++ b/src/schema/field-247.schema.json
@@ -12,6 +12,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "No added entry"
@@ -28,6 +29,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Display note"

--- a/src/schema/field-247.schema.json
+++ b/src/schema/field-247.schema.json
@@ -43,6 +43,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-250.schema.json
+++ b/src/schema/field-250.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "3": {
               "title": "Materials specified",

--- a/src/schema/field-250.schema.json
+++ b/src/schema/field-250.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-251.schema.json
+++ b/src/schema/field-251.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-251.schema.json
+++ b/src/schema/field-251.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-254.schema.json
+++ b/src/schema/field-254.schema.json
@@ -8,6 +8,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"
@@ -18,6 +19,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"

--- a/src/schema/field-254.schema.json
+++ b/src/schema/field-254.schema.json
@@ -30,6 +30,9 @@
       "type": "array",
       "items": {
         "type": "object",
+        "defaultProperties": [
+          "a"
+        ],
         "properties": {
           "6": {
             "title": "Linkage",

--- a/src/schema/field-255.schema.json
+++ b/src/schema/field-255.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-255.schema.json
+++ b/src/schema/field-255.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-256.schema.json
+++ b/src/schema/field-256.schema.json
@@ -8,6 +8,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"
@@ -18,6 +19,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"

--- a/src/schema/field-256.schema.json
+++ b/src/schema/field-256.schema.json
@@ -30,6 +30,9 @@
       "type": "array",
       "items": {
         "type": "object",
+        "defaultProperties": [
+          "a"
+        ],
         "properties": {
           "6": {
             "title": "Linkage",

--- a/src/schema/field-257.schema.json
+++ b/src/schema/field-257.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-257.schema.json
+++ b/src/schema/field-257.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-258.schema.json
+++ b/src/schema/field-258.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-258.schema.json
+++ b/src/schema/field-258.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-260.schema.json
+++ b/src/schema/field-260.schema.json
@@ -13,6 +13,7 @@
           "2",
           "3"
         ],
+        "defaultValue": "\\",
         "code": {
           "2": {
             "title": "Intervening publisher"
@@ -29,6 +30,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-260.schema.json
+++ b/src/schema/field-260.schema.json
@@ -41,6 +41,11 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a",
+            "b",
+            "c"
+          ],
           "properties": {
             "3": {
               "title": "Materials specified",

--- a/src/schema/field-261.schema.json
+++ b/src/schema/field-261.schema.json
@@ -8,6 +8,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"
@@ -18,6 +19,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"

--- a/src/schema/field-261.schema.json
+++ b/src/schema/field-261.schema.json
@@ -30,6 +30,9 @@
       "type": "array",
       "items": {
         "type": "object",
+        "defaultProperties": [
+          "a"
+        ],
         "properties": {
           "6": {
             "title": "Linkage",

--- a/src/schema/field-262.schema.json
+++ b/src/schema/field-262.schema.json
@@ -8,6 +8,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"
@@ -18,6 +19,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"

--- a/src/schema/field-262.schema.json
+++ b/src/schema/field-262.schema.json
@@ -30,6 +30,9 @@
       "type": "array",
       "items": {
         "type": "object",
+        "defaultProperties": [
+          "a"
+        ],
         "properties": {
           "6": {
             "title": "Linkage",

--- a/src/schema/field-263.schema.json
+++ b/src/schema/field-263.schema.json
@@ -8,6 +8,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"
@@ -18,6 +19,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"

--- a/src/schema/field-263.schema.json
+++ b/src/schema/field-263.schema.json
@@ -30,6 +30,9 @@
       "type": "array",
       "items": {
         "type": "object",
+        "defaultProperties": [
+          "a"
+        ],
         "properties": {
           "6": {
             "title": "Linkage",

--- a/src/schema/field-264.schema.json
+++ b/src/schema/field-264.schema.json
@@ -59,6 +59,11 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a",
+            "b",
+            "c"
+          ],
           "properties": {
             "3": {
               "title": "Materials specified",

--- a/src/schema/field-264.schema.json
+++ b/src/schema/field-264.schema.json
@@ -13,6 +13,7 @@
           "2",
           "3"
         ],
+        "defaultValue": "\\",
         "code": {
           "2": {
             "title": "Intervening"
@@ -35,6 +36,7 @@
           "3",
           "4"
         ],
+        "defaultValue": "1",
         "code": {
           "0": {
             "title": "Production"

--- a/src/schema/field-265.schema.json
+++ b/src/schema/field-265.schema.json
@@ -8,6 +8,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"
@@ -18,6 +19,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"

--- a/src/schema/field-265.schema.json
+++ b/src/schema/field-265.schema.json
@@ -30,6 +30,9 @@
       "type": "array",
       "items": {
         "type": "object",
+        "defaultProperties": [
+          "a"
+        ],
         "properties": {
           "6": {
             "title": "Linkage",

--- a/src/schema/field-270.schema.json
+++ b/src/schema/field-270.schema.json
@@ -13,6 +13,7 @@
           "1",
           "2"
         ],
+        "defaultValue": "\\",
         "code": {
           "1": {
             "title": "Primary"
@@ -33,6 +34,7 @@
           "0",
           "7"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Mailing"

--- a/src/schema/field-270.schema.json
+++ b/src/schema/field-270.schema.json
@@ -51,6 +51,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "4": {
               "title": "Relationship",

--- a/src/schema/field-300.schema.json
+++ b/src/schema/field-300.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "3": {
               "title": "Materials specified",

--- a/src/schema/field-300.schema.json
+++ b/src/schema/field-300.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-306.schema.json
+++ b/src/schema/field-306.schema.json
@@ -8,6 +8,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"
@@ -18,6 +19,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"

--- a/src/schema/field-306.schema.json
+++ b/src/schema/field-306.schema.json
@@ -30,6 +30,9 @@
       "type": "array",
       "items": {
         "type": "object",
+        "defaultProperties": [
+          "a"
+        ],
         "properties": {
           "6": {
             "title": "Linkage",

--- a/src/schema/field-307.schema.json
+++ b/src/schema/field-307.schema.json
@@ -37,6 +37,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-307.schema.json
+++ b/src/schema/field-307.schema.json
@@ -12,6 +12,7 @@
           "\\",
           "8"
         ],
+        "defaultValue": "\\",
         "code": {
           "8": {
             "title": "No display constant generated"
@@ -25,6 +26,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-310.schema.json
+++ b/src/schema/field-310.schema.json
@@ -8,6 +8,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"
@@ -18,6 +19,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"

--- a/src/schema/field-310.schema.json
+++ b/src/schema/field-310.schema.json
@@ -30,6 +30,9 @@
       "type": "array",
       "items": {
         "type": "object",
+        "defaultProperties": [
+          "a"
+        ],
         "properties": {
           "6": {
             "title": "Linkage",

--- a/src/schema/field-321.schema.json
+++ b/src/schema/field-321.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-321.schema.json
+++ b/src/schema/field-321.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-336.schema.json
+++ b/src/schema/field-336.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-336.schema.json
+++ b/src/schema/field-336.schema.json
@@ -31,6 +31,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a",
+            "2"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-337.schema.json
+++ b/src/schema/field-337.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-337.schema.json
+++ b/src/schema/field-337.schema.json
@@ -31,6 +31,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a",
+            "2"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-338.schema.json
+++ b/src/schema/field-338.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-338.schema.json
+++ b/src/schema/field-338.schema.json
@@ -31,6 +31,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a",
+            "2"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-340.schema.json
+++ b/src/schema/field-340.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-340.schema.json
+++ b/src/schema/field-340.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-341.schema.json
+++ b/src/schema/field-341.schema.json
@@ -13,6 +13,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Adaptive features to access primary content"
@@ -29,6 +30,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-341.schema.json
+++ b/src/schema/field-341.schema.json
@@ -41,6 +41,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "2": {
               "title": "Source",

--- a/src/schema/field-342.schema.json
+++ b/src/schema/field-342.schema.json
@@ -12,6 +12,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Horizontal coordinate system"
@@ -35,6 +36,7 @@
           "7",
           "8"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Geographic"

--- a/src/schema/field-342.schema.json
+++ b/src/schema/field-342.schema.json
@@ -71,6 +71,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "2": {
               "title": "Reference method used",

--- a/src/schema/field-343.schema.json
+++ b/src/schema/field-343.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-343.schema.json
+++ b/src/schema/field-343.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-344.schema.json
+++ b/src/schema/field-344.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-344.schema.json
+++ b/src/schema/field-344.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-345.schema.json
+++ b/src/schema/field-345.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-345.schema.json
+++ b/src/schema/field-345.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-346.schema.json
+++ b/src/schema/field-346.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-346.schema.json
+++ b/src/schema/field-346.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-347.schema.json
+++ b/src/schema/field-347.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-347.schema.json
+++ b/src/schema/field-347.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-348.schema.json
+++ b/src/schema/field-348.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-348.schema.json
+++ b/src/schema/field-348.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-351.schema.json
+++ b/src/schema/field-351.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "3": {
               "title": "Materials specified",

--- a/src/schema/field-351.schema.json
+++ b/src/schema/field-351.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-352.schema.json
+++ b/src/schema/field-352.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-352.schema.json
+++ b/src/schema/field-352.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-355.schema.json
+++ b/src/schema/field-355.schema.json
@@ -17,6 +17,7 @@
           "5",
           "8"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Document"
@@ -45,6 +46,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-355.schema.json
+++ b/src/schema/field-355.schema.json
@@ -57,6 +57,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-357.schema.json
+++ b/src/schema/field-357.schema.json
@@ -8,6 +8,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"
@@ -18,6 +19,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"

--- a/src/schema/field-362.schema.json
+++ b/src/schema/field-362.schema.json
@@ -37,6 +37,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-362.schema.json
+++ b/src/schema/field-362.schema.json
@@ -12,6 +12,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Formatted style"
@@ -25,6 +26,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-363.schema.json
+++ b/src/schema/field-363.schema.json
@@ -13,6 +13,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Starting information"
@@ -33,6 +34,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Closed"

--- a/src/schema/field-363.schema.json
+++ b/src/schema/field-363.schema.json
@@ -51,6 +51,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-365.schema.json
+++ b/src/schema/field-365.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "2": {
               "title": "Source of price type code",

--- a/src/schema/field-365.schema.json
+++ b/src/schema/field-365.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-366.schema.json
+++ b/src/schema/field-366.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-366.schema.json
+++ b/src/schema/field-366.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "2": {
               "title": "Source of availability status code",

--- a/src/schema/field-370.schema.json
+++ b/src/schema/field-370.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-370.schema.json
+++ b/src/schema/field-370.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-377.schema.json
+++ b/src/schema/field-377.schema.json
@@ -37,6 +37,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-377.schema.json
+++ b/src/schema/field-377.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -22,6 +23,7 @@
           "\\",
           "7"
         ],
+        "defaultValue": "\\",
         "code": {
           "7": {
             "title": "Source specified in subfield $2"

--- a/src/schema/field-380.schema.json
+++ b/src/schema/field-380.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-380.schema.json
+++ b/src/schema/field-380.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-381.schema.json
+++ b/src/schema/field-381.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-381.schema.json
+++ b/src/schema/field-381.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-382.schema.json
+++ b/src/schema/field-382.schema.json
@@ -51,6 +51,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-382.schema.json
+++ b/src/schema/field-382.schema.json
@@ -13,6 +13,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Medium of performance"
@@ -33,6 +34,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Not intended for access"

--- a/src/schema/field-383.schema.json
+++ b/src/schema/field-383.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "2": {
               "title": "Source",

--- a/src/schema/field-383.schema.json
+++ b/src/schema/field-383.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-384.schema.json
+++ b/src/schema/field-384.schema.json
@@ -41,6 +41,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "3": {
               "title": "Materials specified",

--- a/src/schema/field-384.schema.json
+++ b/src/schema/field-384.schema.json
@@ -13,6 +13,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Original key"
@@ -29,6 +30,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-385.schema.json
+++ b/src/schema/field-385.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-385.schema.json
+++ b/src/schema/field-385.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-386.schema.json
+++ b/src/schema/field-386.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-386.schema.json
+++ b/src/schema/field-386.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-388.schema.json
+++ b/src/schema/field-388.schema.json
@@ -13,6 +13,7 @@
           "1",
           "2"
         ],
+        "defaultValue": "\\",
         "code": {
           "1": {
             "title": "Creation of work"
@@ -29,6 +30,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-388.schema.json
+++ b/src/schema/field-388.schema.json
@@ -41,6 +41,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-400.schema.json
+++ b/src/schema/field-400.schema.json
@@ -14,6 +14,7 @@
           "2",
           "3"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Forename"
@@ -36,6 +37,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Main entry not represented by pronoun"

--- a/src/schema/field-400.schema.json
+++ b/src/schema/field-400.schema.json
@@ -51,6 +51,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "4": {
               "title": "Relationship",

--- a/src/schema/field-410.schema.json
+++ b/src/schema/field-410.schema.json
@@ -13,6 +13,7 @@
           "1",
           "2"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Inverted name"
@@ -32,6 +33,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Main entry not represented by pronoun"

--- a/src/schema/field-410.schema.json
+++ b/src/schema/field-410.schema.json
@@ -47,6 +47,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "4": {
               "title": "Relationship",

--- a/src/schema/field-411.schema.json
+++ b/src/schema/field-411.schema.json
@@ -13,6 +13,7 @@
           "1",
           "2"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Inverted name"
@@ -32,6 +33,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Main entry not represented by pronoun"

--- a/src/schema/field-411.schema.json
+++ b/src/schema/field-411.schema.json
@@ -47,6 +47,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "4": {
               "title": "Relationship",

--- a/src/schema/field-440.schema.json
+++ b/src/schema/field-440.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Nonfiling characters",
         "type": "string",
         "const": "0",
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "9"

--- a/src/schema/field-440.schema.json
+++ b/src/schema/field-440.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number",

--- a/src/schema/field-490.schema.json
+++ b/src/schema/field-490.schema.json
@@ -37,6 +37,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "3": {
               "title": "Materials specified",

--- a/src/schema/field-490.schema.json
+++ b/src/schema/field-490.schema.json
@@ -12,6 +12,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Series not traced"
@@ -25,6 +26,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-500.schema.json
+++ b/src/schema/field-500.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "3": {
               "title": "Materials specified",

--- a/src/schema/field-500.schema.json
+++ b/src/schema/field-500.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-501.schema.json
+++ b/src/schema/field-501.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "5": {
               "title": "Institution to which field applies",

--- a/src/schema/field-501.schema.json
+++ b/src/schema/field-501.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-502.schema.json
+++ b/src/schema/field-502.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-502.schema.json
+++ b/src/schema/field-502.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-504.schema.json
+++ b/src/schema/field-504.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-504.schema.json
+++ b/src/schema/field-504.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-505.schema.json
+++ b/src/schema/field-505.schema.json
@@ -14,6 +14,7 @@
           "2",
           "8"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Contents"
@@ -36,6 +37,7 @@
           "\\",
           "0"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Enhanced"

--- a/src/schema/field-505.schema.json
+++ b/src/schema/field-505.schema.json
@@ -51,6 +51,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-506.schema.json
+++ b/src/schema/field-506.schema.json
@@ -13,6 +13,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "No restrictions"
@@ -29,6 +30,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-506.schema.json
+++ b/src/schema/field-506.schema.json
@@ -41,6 +41,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "2": {
               "title": "Source of term",

--- a/src/schema/field-507.schema.json
+++ b/src/schema/field-507.schema.json
@@ -8,6 +8,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"
@@ -18,6 +19,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"

--- a/src/schema/field-507.schema.json
+++ b/src/schema/field-507.schema.json
@@ -30,6 +30,9 @@
       "type": "array",
       "items": {
         "type": "object",
+        "defaultProperties": [
+          "a"
+        ],
         "properties": {
           "6": {
             "title": "Linkage",

--- a/src/schema/field-508.schema.json
+++ b/src/schema/field-508.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-508.schema.json
+++ b/src/schema/field-508.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-510.schema.json
+++ b/src/schema/field-510.schema.json
@@ -49,6 +49,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "3": {
               "title": "Materials specified",

--- a/src/schema/field-510.schema.json
+++ b/src/schema/field-510.schema.json
@@ -15,6 +15,7 @@
           "3",
           "4"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Coverage unknown"
@@ -37,6 +38,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-511.schema.json
+++ b/src/schema/field-511.schema.json
@@ -49,6 +49,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-511.schema.json
+++ b/src/schema/field-511.schema.json
@@ -15,6 +15,7 @@
           "2",
           "3"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "No display constant generated"
@@ -37,6 +38,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-512.schema.json
+++ b/src/schema/field-512.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-512.schema.json
+++ b/src/schema/field-512.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-513.schema.json
+++ b/src/schema/field-513.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-513.schema.json
+++ b/src/schema/field-513.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-514.schema.json
+++ b/src/schema/field-514.schema.json
@@ -8,6 +8,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"
@@ -18,6 +19,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"

--- a/src/schema/field-514.schema.json
+++ b/src/schema/field-514.schema.json
@@ -30,6 +30,9 @@
       "type": "array",
       "items": {
         "type": "object",
+        "defaultProperties": [
+          "a"
+        ],
         "properties": {
           "6": {
             "title": "Linkage",

--- a/src/schema/field-515.schema.json
+++ b/src/schema/field-515.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-515.schema.json
+++ b/src/schema/field-515.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-516.schema.json
+++ b/src/schema/field-516.schema.json
@@ -37,6 +37,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-516.schema.json
+++ b/src/schema/field-516.schema.json
@@ -12,6 +12,7 @@
           "\\",
           "8"
         ],
+        "defaultValue": "\\",
         "code": {
           "8": {
             "title": "No display constant generated"
@@ -25,6 +26,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-517.schema.json
+++ b/src/schema/field-517.schema.json
@@ -36,6 +36,9 @@
       "type": "array",
       "items": {
         "type": "object",
+        "defaultProperties": [
+          "a"
+        ],
         "properties": {
           "a": {
             "title": "Different formats",

--- a/src/schema/field-517.schema.json
+++ b/src/schema/field-517.schema.json
@@ -11,6 +11,7 @@
         "0",
         "1"
       ],
+      "defaultValue": "\\",
       "code": {
         "0": {
           "title": "Nonfiction"
@@ -24,6 +25,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"

--- a/src/schema/field-518.schema.json
+++ b/src/schema/field-518.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-518.schema.json
+++ b/src/schema/field-518.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-520.schema.json
+++ b/src/schema/field-520.schema.json
@@ -57,6 +57,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "2": {
               "title": "Source",

--- a/src/schema/field-520.schema.json
+++ b/src/schema/field-520.schema.json
@@ -17,6 +17,7 @@
           "4",
           "8"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Subject"
@@ -45,6 +46,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-521.schema.json
+++ b/src/schema/field-521.schema.json
@@ -57,6 +57,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "3": {
               "title": "Materials specified",

--- a/src/schema/field-521.schema.json
+++ b/src/schema/field-521.schema.json
@@ -17,6 +17,7 @@
           "4",
           "8"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Reading grade level"
@@ -45,6 +46,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-522.schema.json
+++ b/src/schema/field-522.schema.json
@@ -37,6 +37,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-522.schema.json
+++ b/src/schema/field-522.schema.json
@@ -12,6 +12,7 @@
           "\\",
           "8"
         ],
+        "defaultValue": "\\",
         "code": {
           "8": {
             "title": "No display constant generated"
@@ -25,6 +26,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-524.schema.json
+++ b/src/schema/field-524.schema.json
@@ -37,6 +37,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "2": {
               "title": "Source of schema used",

--- a/src/schema/field-524.schema.json
+++ b/src/schema/field-524.schema.json
@@ -12,6 +12,7 @@
           "\\",
           "8"
         ],
+        "defaultValue": "\\",
         "code": {
           "8": {
             "title": "No display constant generated"
@@ -25,6 +26,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-525.schema.json
+++ b/src/schema/field-525.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-525.schema.json
+++ b/src/schema/field-525.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-526.schema.json
+++ b/src/schema/field-526.schema.json
@@ -37,6 +37,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "5": {
               "title": "Institution to which field applies",

--- a/src/schema/field-526.schema.json
+++ b/src/schema/field-526.schema.json
@@ -12,6 +12,7 @@
           "0",
           "8"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Reading program"
@@ -25,6 +26,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-527.schema.json
+++ b/src/schema/field-527.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-527.schema.json
+++ b/src/schema/field-527.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-530.schema.json
+++ b/src/schema/field-530.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "3": {
               "title": "Materials specified",

--- a/src/schema/field-530.schema.json
+++ b/src/schema/field-530.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-532.schema.json
+++ b/src/schema/field-532.schema.json
@@ -45,6 +45,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-532.schema.json
+++ b/src/schema/field-532.schema.json
@@ -14,6 +14,7 @@
           "2",
           "8"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Accessibility technical details"
@@ -33,6 +34,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-533.schema.json
+++ b/src/schema/field-533.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "3": {
               "title": "Materials specified",

--- a/src/schema/field-533.schema.json
+++ b/src/schema/field-533.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-534.schema.json
+++ b/src/schema/field-534.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "3": {
               "title": "Materials specified",

--- a/src/schema/field-534.schema.json
+++ b/src/schema/field-534.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-535.schema.json
+++ b/src/schema/field-535.schema.json
@@ -45,6 +45,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "3": {
               "title": "Materials specified",

--- a/src/schema/field-535.schema.json
+++ b/src/schema/field-535.schema.json
@@ -14,6 +14,7 @@
           "2",
           "3"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Repository (AM) [OBSOLETE]"
@@ -33,6 +34,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-536.schema.json
+++ b/src/schema/field-536.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-536.schema.json
+++ b/src/schema/field-536.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-538.schema.json
+++ b/src/schema/field-538.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "3": {
               "title": "Materials specified ",

--- a/src/schema/field-538.schema.json
+++ b/src/schema/field-538.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-540.schema.json
+++ b/src/schema/field-540.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "2": {
               "title": "Source of term",

--- a/src/schema/field-540.schema.json
+++ b/src/schema/field-540.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-541.schema.json
+++ b/src/schema/field-541.schema.json
@@ -13,6 +13,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Private"
@@ -29,6 +30,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-541.schema.json
+++ b/src/schema/field-541.schema.json
@@ -41,6 +41,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "patternProperties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-542.schema.json
+++ b/src/schema/field-542.schema.json
@@ -13,6 +13,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Private"
@@ -29,6 +30,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-543.schema.json
+++ b/src/schema/field-543.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-543.schema.json
+++ b/src/schema/field-543.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-544.schema.json
+++ b/src/schema/field-544.schema.json
@@ -13,6 +13,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Associated materials"
@@ -29,6 +30,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-544.schema.json
+++ b/src/schema/field-544.schema.json
@@ -41,6 +41,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "3": {
               "title": "Materials specified",

--- a/src/schema/field-545.schema.json
+++ b/src/schema/field-545.schema.json
@@ -13,6 +13,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Biographical sketch"
@@ -29,6 +30,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-545.schema.json
+++ b/src/schema/field-545.schema.json
@@ -41,6 +41,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-546.schema.json
+++ b/src/schema/field-546.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "3": {
               "title": "Materials specified",

--- a/src/schema/field-546.schema.json
+++ b/src/schema/field-546.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-547.schema.json
+++ b/src/schema/field-547.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-547.schema.json
+++ b/src/schema/field-547.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-550.schema.json
+++ b/src/schema/field-550.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-550.schema.json
+++ b/src/schema/field-550.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-552.schema.json
+++ b/src/schema/field-552.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-552.schema.json
+++ b/src/schema/field-552.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-555.schema.json
+++ b/src/schema/field-555.schema.json
@@ -41,6 +41,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "3": {
               "title": "Materials specified",

--- a/src/schema/field-555.schema.json
+++ b/src/schema/field-555.schema.json
@@ -13,6 +13,7 @@
           "0",
           "8"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Finding aids"
@@ -29,6 +30,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-556.schema.json
+++ b/src/schema/field-556.schema.json
@@ -37,6 +37,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-556.schema.json
+++ b/src/schema/field-556.schema.json
@@ -12,6 +12,7 @@
           "\\",
           "8"
         ],
+        "defaultValue": "\\",
         "code": {
           "8": {
             "title": "No display constant generated"
@@ -25,6 +26,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-561.schema.json
+++ b/src/schema/field-561.schema.json
@@ -13,6 +13,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Private"
@@ -29,6 +30,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-561.schema.json
+++ b/src/schema/field-561.schema.json
@@ -41,6 +41,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "3": {
               "title": "Materials specified",

--- a/src/schema/field-562.schema.json
+++ b/src/schema/field-562.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "3": {
               "title": "Materials specified",

--- a/src/schema/field-562.schema.json
+++ b/src/schema/field-562.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-563.schema.json
+++ b/src/schema/field-563.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "3": {
               "title": "Materials specified",

--- a/src/schema/field-563.schema.json
+++ b/src/schema/field-563.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-565.schema.json
+++ b/src/schema/field-565.schema.json
@@ -41,6 +41,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "3": {
               "title": "Materials specified",

--- a/src/schema/field-565.schema.json
+++ b/src/schema/field-565.schema.json
@@ -13,6 +13,7 @@
           "0",
           "8"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Case file characteristics"
@@ -29,6 +30,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-567.schema.json
+++ b/src/schema/field-567.schema.json
@@ -12,6 +12,7 @@
           "\\",
           "8"
         ],
+        "defaultValue": "\\",
         "code": {
           "8": {
             "title": "No display constant generated"
@@ -25,6 +26,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-567.schema.json
+++ b/src/schema/field-567.schema.json
@@ -37,6 +37,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-570.schema.json
+++ b/src/schema/field-570.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-570.schema.json
+++ b/src/schema/field-570.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-580.schema.json
+++ b/src/schema/field-580.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-580.schema.json
+++ b/src/schema/field-580.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-581.schema.json
+++ b/src/schema/field-581.schema.json
@@ -37,6 +37,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "3": {
               "title": "Materials specified",

--- a/src/schema/field-581.schema.json
+++ b/src/schema/field-581.schema.json
@@ -12,6 +12,7 @@
           "\\",
           "8"
         ],
+        "defaultValue": "\\",
         "code": {
           "8": {
             "title": "No display constant generated"
@@ -25,6 +26,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-583.schema.json
+++ b/src/schema/field-583.schema.json
@@ -13,6 +13,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Private"
@@ -29,6 +30,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-583.schema.json
+++ b/src/schema/field-583.schema.json
@@ -41,6 +41,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "2": {
               "title": "Source of term",

--- a/src/schema/field-584.schema.json
+++ b/src/schema/field-584.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "3": {
               "title": "Materials specified",

--- a/src/schema/field-584.schema.json
+++ b/src/schema/field-584.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-585.schema.json
+++ b/src/schema/field-585.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "3": {
               "title": "Materials specified",

--- a/src/schema/field-585.schema.json
+++ b/src/schema/field-585.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-586.schema.json
+++ b/src/schema/field-586.schema.json
@@ -37,6 +37,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "3": {
               "title": "Materials specified",

--- a/src/schema/field-586.schema.json
+++ b/src/schema/field-586.schema.json
@@ -12,6 +12,7 @@
           "\\",
           "8"
         ],
+        "defaultValue": "\\",
         "code": {
           "8": {
             "title": "No display constant generated"
@@ -25,6 +26,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-588.schema.json
+++ b/src/schema/field-588.schema.json
@@ -13,6 +13,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Source of description"
@@ -29,6 +30,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-588.schema.json
+++ b/src/schema/field-588.schema.json
@@ -41,6 +41,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "5": {
               "title": "Institution to which field applies",

--- a/src/schema/field-600.schema.json
+++ b/src/schema/field-600.schema.json
@@ -14,6 +14,7 @@
           "2",
           "3"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Forename"
@@ -42,6 +43,7 @@
           "6",
           "7"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Library of Congress Subject Headings"

--- a/src/schema/field-600.schema.json
+++ b/src/schema/field-600.schema.json
@@ -75,6 +75,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-610.schema.json
+++ b/src/schema/field-610.schema.json
@@ -71,6 +71,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-610.schema.json
+++ b/src/schema/field-610.schema.json
@@ -13,6 +13,7 @@
           "1",
           "2"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Inverted name"
@@ -38,6 +39,7 @@
           "6",
           "7"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Library of Congress Subject Headings"

--- a/src/schema/field-611.schema.json
+++ b/src/schema/field-611.schema.json
@@ -71,6 +71,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-611.schema.json
+++ b/src/schema/field-611.schema.json
@@ -13,6 +13,7 @@
           "1",
           "2"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Inverted name"
@@ -38,6 +39,7 @@
           "6",
           "7"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Library of Congress Subject Headings"

--- a/src/schema/field-630.schema.json
+++ b/src/schema/field-630.schema.json
@@ -12,6 +12,7 @@
           "0",
           "\\"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "9"
@@ -34,6 +35,7 @@
           "6",
           "7"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Library of Congress Subject Headings"

--- a/src/schema/field-630.schema.json
+++ b/src/schema/field-630.schema.json
@@ -67,6 +67,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-647.schema.json
+++ b/src/schema/field-647.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -28,6 +29,7 @@
           "6",
           "7"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Library of Congress Subject Headings"

--- a/src/schema/field-647.schema.json
+++ b/src/schema/field-647.schema.json
@@ -61,6 +61,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-648.schema.json
+++ b/src/schema/field-648.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -23,6 +24,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Date or time period covered or depicted [OBSOLETE]"

--- a/src/schema/field-648.schema.json
+++ b/src/schema/field-648.schema.json
@@ -41,6 +41,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-650.schema.json
+++ b/src/schema/field-650.schema.json
@@ -14,6 +14,7 @@
           "1",
           "2"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "No level specified"
@@ -42,6 +43,7 @@
           "6",
           "7"
         ],
+        "defaultValue": "4",
         "code": {
           "0": {
             "title": "Library of Congress Subject Headings"

--- a/src/schema/field-650.schema.json
+++ b/src/schema/field-650.schema.json
@@ -75,6 +75,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-651.schema.json
+++ b/src/schema/field-651.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -28,6 +29,7 @@
           "6",
           "7"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Library of Congress Subject Headings"

--- a/src/schema/field-651.schema.json
+++ b/src/schema/field-651.schema.json
@@ -61,6 +61,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-653.schema.json
+++ b/src/schema/field-653.schema.json
@@ -14,6 +14,7 @@
           "1",
           "2"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "No level specified"
@@ -42,6 +43,7 @@
           "5",
           "6"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Topical term"

--- a/src/schema/field-653.schema.json
+++ b/src/schema/field-653.schema.json
@@ -75,6 +75,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-654.schema.json
+++ b/src/schema/field-654.schema.json
@@ -14,6 +14,7 @@
           "1",
           "2"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "No level specified"
@@ -33,6 +34,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-654.schema.json
+++ b/src/schema/field-654.schema.json
@@ -45,6 +45,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-655.schema.json
+++ b/src/schema/field-655.schema.json
@@ -12,6 +12,7 @@
           "\\",
           "0"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Faceted"
@@ -34,6 +35,7 @@
           "6",
           "7"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Library of Congress Subject Headings"

--- a/src/schema/field-655.schema.json
+++ b/src/schema/field-655.schema.json
@@ -67,6 +67,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-656.schema.json
+++ b/src/schema/field-656.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-656.schema.json
+++ b/src/schema/field-656.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Source of term",
         "type": "string",
         "const": "7",
+        "defaultValue": "\\",
         "code": {
           "7": {
             "title": "Source specified in subfield $2"

--- a/src/schema/field-657.schema.json
+++ b/src/schema/field-657.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-657.schema.json
+++ b/src/schema/field-657.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Source of term",
         "type": "string",
         "const": "7",
+        "defaultValue": "\\",
         "code": {
           "7": {
             "title": "Source specified in subfield $2"

--- a/src/schema/field-658.schema.json
+++ b/src/schema/field-658.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "2": {
               "title": "Source of term or code",

--- a/src/schema/field-658.schema.json
+++ b/src/schema/field-658.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-662.schema.json
+++ b/src/schema/field-662.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-662.schema.json
+++ b/src/schema/field-662.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-688.schema.json
+++ b/src/schema/field-688.schema.json
@@ -37,6 +37,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-688.schema.json
+++ b/src/schema/field-688.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -22,6 +23,7 @@
           "\\",
           "7"
         ],
+        "defaultValue": "\\",
         "code": {
           "7": {
             "title": "Source specified in subfield $2"

--- a/src/schema/field-700.schema.json
+++ b/src/schema/field-700.schema.json
@@ -63,6 +63,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-700.schema.json
+++ b/src/schema/field-700.schema.json
@@ -14,6 +14,7 @@
           "2",
           "3"
         ],
+        "defaultValue": "0",
         "code": {
           "0": {
             "title": "Forename"
@@ -39,6 +40,7 @@
           "2",
           "3"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Alternative entry (BK CF MP MU SE MX) [OBSOLETE]"

--- a/src/schema/field-710-register.schema.json
+++ b/src/schema/field-710-register.schema.json
@@ -13,6 +13,7 @@
           "1",
           "2"
         ],
+        "defaultValue": "0",
         "code": {
           "0": {
             "title": "Inverted name"
@@ -35,6 +36,7 @@
           "2",
           "3"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Alternative entry (BK CF MP MU SE MX) [OBSOLETE]"

--- a/src/schema/field-710-register.schema.json
+++ b/src/schema/field-710-register.schema.json
@@ -59,6 +59,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "t",
+            "x"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-710-work.schema.json
+++ b/src/schema/field-710-work.schema.json
@@ -13,6 +13,7 @@
           "1",
           "2"
         ],
+        "defaultValue": "0",
         "code": {
           "0": {
             "title": "Inverted name"
@@ -35,6 +36,7 @@
           "2",
           "3"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Alternative entry (BK CF MP MU SE MX) [OBSOLETE]"

--- a/src/schema/field-710-work.schema.json
+++ b/src/schema/field-710-work.schema.json
@@ -59,6 +59,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "t",
+            "x"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-711-register.schema.json
+++ b/src/schema/field-711-register.schema.json
@@ -13,6 +13,7 @@
           "1",
           "2"
         ],
+        "defaultValue": "0",
         "code": {
           "0": {
             "title": "Inverted name"
@@ -35,6 +36,7 @@
           "2",
           "3"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Alternative entry (BK CF MP MU SE MX) [OBSOLETE]"

--- a/src/schema/field-711-register.schema.json
+++ b/src/schema/field-711-register.schema.json
@@ -59,6 +59,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "t",
+            "x"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-711-work.schema.json
+++ b/src/schema/field-711-work.schema.json
@@ -13,6 +13,7 @@
           "1",
           "2"
         ],
+        "defaultValue": "0",
         "code": {
           "0": {
             "title": "Inverted name"
@@ -35,6 +36,7 @@
           "2",
           "3"
         ],
+        "defaultValue": "0",
         "code": {
           "0": {
             "title": "Alternative entry (BK CF MP MU SE MX) [OBSOLETE]"

--- a/src/schema/field-711-work.schema.json
+++ b/src/schema/field-711-work.schema.json
@@ -59,6 +59,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "t",
+            "x"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-720-register.schema.json
+++ b/src/schema/field-720-register.schema.json
@@ -13,6 +13,7 @@
           "1",
           "2"
         ],
+        "defaultValue": "0",
         "code": {
           "1": {
             "title": "Personal"
@@ -29,6 +30,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-720-register.schema.json
+++ b/src/schema/field-720-register.schema.json
@@ -41,6 +41,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "t",
+            "x"
+          ],
           "properties": {
             "0": {
               "title": "INSI",

--- a/src/schema/field-720-work.schema.json
+++ b/src/schema/field-720-work.schema.json
@@ -13,6 +13,7 @@
           "1",
           "2"
         ],
+        "defaultValue": "0",
         "code": {
           "1": {
             "title": "Personal"
@@ -29,6 +30,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-720-work.schema.json
+++ b/src/schema/field-720-work.schema.json
@@ -41,6 +41,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "t",
+            "x"
+          ],
           "properties": {
             "0": {
               "title": "INSI",

--- a/src/schema/field-730.schema.json
+++ b/src/schema/field-730.schema.json
@@ -55,6 +55,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "t",
+            "x"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-730.schema.json
+++ b/src/schema/field-730.schema.json
@@ -12,6 +12,7 @@
           "0",
           "\\"
         ],
+        "defaultValue": "0",
         "code": {
           "0": {
             "title": "9"
@@ -31,6 +32,7 @@
           "2",
           "3"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Alternative entry (BK CF MP MU SE MX) [OBSOLETE]"

--- a/src/schema/field-740.schema.json
+++ b/src/schema/field-740.schema.json
@@ -55,6 +55,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "t",
+            "x"
+          ],
           "properties": {
             "5": {
               "title": "Institution to which field applies",

--- a/src/schema/field-740.schema.json
+++ b/src/schema/field-740.schema.json
@@ -12,6 +12,7 @@
           "0",
           "\\"
         ],
+        "defaultValue": "0",
         "code": {
           "0": {
             "title": "9"
@@ -31,6 +32,7 @@
           "2",
           "3"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Alternative entry (BK AM CF MP MU) [OBSOLETE]"

--- a/src/schema/field-751.schema.json
+++ b/src/schema/field-751.schema.json
@@ -31,6 +31,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "t",
+            "x"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-751.schema.json
+++ b/src/schema/field-751.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "0",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-752.schema.json
+++ b/src/schema/field-752.schema.json
@@ -31,6 +31,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "t",
+            "x"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-752.schema.json
+++ b/src/schema/field-752.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "0",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-753.schema.json
+++ b/src/schema/field-753.schema.json
@@ -31,6 +31,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "t",
+            "x"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-753.schema.json
+++ b/src/schema/field-753.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "0",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-754.schema.json
+++ b/src/schema/field-754.schema.json
@@ -31,6 +31,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "t",
+            "x"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-754.schema.json
+++ b/src/schema/field-754.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "0",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-755.schema.json
+++ b/src/schema/field-755.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "0",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-755.schema.json
+++ b/src/schema/field-755.schema.json
@@ -31,6 +31,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "t",
+            "x"
+          ],
           "properties": {
             "2": {
               "title": "Source of term",

--- a/src/schema/field-758.schema.json
+++ b/src/schema/field-758.schema.json
@@ -31,6 +31,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "t",
+            "x"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-758.schema.json
+++ b/src/schema/field-758.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "0",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-760-register.schema.json
+++ b/src/schema/field-760-register.schema.json
@@ -12,6 +12,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "0",
         "code": {
           "0": {
             "title": "Display note"
@@ -28,6 +29,7 @@
           "\\",
           "8"
         ],
+        "defaultValue": "\\",
         "code": {
           "8": {
             "title": "No display constant generated"

--- a/src/schema/field-760-register.schema.json
+++ b/src/schema/field-760-register.schema.json
@@ -43,6 +43,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "t",
+            "x"
+          ],
           "properties": {
             "4": {
               "title": "Relationship",

--- a/src/schema/field-760-work.schema.json
+++ b/src/schema/field-760-work.schema.json
@@ -12,6 +12,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "0",
         "code": {
           "0": {
             "title": "Display note"
@@ -28,6 +29,7 @@
           "\\",
           "8"
         ],
+        "defaultValue": "\\",
         "code": {
           "8": {
             "title": "No display constant generated"

--- a/src/schema/field-760-work.schema.json
+++ b/src/schema/field-760-work.schema.json
@@ -43,6 +43,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "t",
+            "x"
+          ],
           "properties": {
             "4": {
               "title": "Relationship",

--- a/src/schema/field-762-register.schema.json
+++ b/src/schema/field-762-register.schema.json
@@ -12,6 +12,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "0",
         "code": {
           "0": {
             "title": "Display note"
@@ -28,6 +29,7 @@
           "\\",
           "8"
         ],
+        "defaultValue": "\\",
         "code": {
           "8": {
             "title": "No display constant generated"

--- a/src/schema/field-762-register.schema.json
+++ b/src/schema/field-762-register.schema.json
@@ -43,6 +43,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "t",
+            "x"
+          ],
           "properties": {
             "4": {
               "title": "Relationship",

--- a/src/schema/field-762-work.schema.json
+++ b/src/schema/field-762-work.schema.json
@@ -12,6 +12,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "0",
         "code": {
           "0": {
             "title": "Display note"
@@ -28,6 +29,7 @@
           "\\",
           "8"
         ],
+        "defaultValue": "\\",
         "code": {
           "8": {
             "title": "No display constant generated"

--- a/src/schema/field-762-work.schema.json
+++ b/src/schema/field-762-work.schema.json
@@ -43,6 +43,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "t",
+            "x"
+          ],
           "properties": {
             "4": {
               "title": "Relationship",

--- a/src/schema/field-765-register.schema.json
+++ b/src/schema/field-765-register.schema.json
@@ -12,6 +12,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "0",
         "code": {
           "0": {
             "title": "Display note"
@@ -28,6 +29,7 @@
           "\\",
           "8"
         ],
+        "defaultValue": "\\",
         "code": {
           "8": {
             "title": "No display constant generated"

--- a/src/schema/field-765-register.schema.json
+++ b/src/schema/field-765-register.schema.json
@@ -43,6 +43,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "t",
+            "x"
+          ],
           "properties": {
             "4": {
               "title": "Relationship",

--- a/src/schema/field-765-work.schema.json
+++ b/src/schema/field-765-work.schema.json
@@ -12,6 +12,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "0",
         "code": {
           "0": {
             "title": "Display note"
@@ -28,6 +29,7 @@
           "\\",
           "8"
         ],
+        "defaultValue": "\\",
         "code": {
           "8": {
             "title": "No display constant generated"

--- a/src/schema/field-765-work.schema.json
+++ b/src/schema/field-765-work.schema.json
@@ -43,6 +43,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "t",
+            "x"
+          ],
           "properties": {
             "4": {
               "title": "Relationship",

--- a/src/schema/field-767-register.schema.json
+++ b/src/schema/field-767-register.schema.json
@@ -12,6 +12,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "0",
         "code": {
           "0": {
             "title": "Display note"
@@ -28,6 +29,7 @@
           "\\",
           "8"
         ],
+        "defaultValue": "\\",
         "code": {
           "8": {
             "title": "No display constant generated"

--- a/src/schema/field-767-register.schema.json
+++ b/src/schema/field-767-register.schema.json
@@ -43,6 +43,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "t",
+            "x"
+          ],
           "properties": {
             "4": {
               "title": "Relationship",

--- a/src/schema/field-767-work.schema.json
+++ b/src/schema/field-767-work.schema.json
@@ -12,6 +12,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "0",
         "code": {
           "0": {
             "title": "Display note"
@@ -28,6 +29,7 @@
           "\\",
           "8"
         ],
+        "defaultValue": "\\",
         "code": {
           "8": {
             "title": "No display constant generated"

--- a/src/schema/field-767-work.schema.json
+++ b/src/schema/field-767-work.schema.json
@@ -43,6 +43,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "t",
+            "x"
+          ],
           "properties": {
             "4": {
               "title": "Relationship",

--- a/src/schema/field-770-register.schema.json
+++ b/src/schema/field-770-register.schema.json
@@ -12,6 +12,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "0",
         "code": {
           "0": {
             "title": "Display note"
@@ -28,6 +29,7 @@
           "\\",
           "8"
         ],
+        "defaultValue": "\\",
         "code": {
           "8": {
             "title": "No display constant generated"

--- a/src/schema/field-770-register.schema.json
+++ b/src/schema/field-770-register.schema.json
@@ -43,6 +43,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "t",
+            "x"
+          ],
           "properties": {
             "4": {
               "title": "Relationship",

--- a/src/schema/field-770-work.schema.json
+++ b/src/schema/field-770-work.schema.json
@@ -12,6 +12,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "0",
         "code": {
           "0": {
             "title": "Display note"
@@ -28,6 +29,7 @@
           "\\",
           "8"
         ],
+        "defaultValue": "\\",
         "code": {
           "8": {
             "title": "No display constant generated"

--- a/src/schema/field-770-work.schema.json
+++ b/src/schema/field-770-work.schema.json
@@ -43,6 +43,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "t",
+            "x"
+          ],
           "properties": {
             "4": {
               "title": "Relationship",

--- a/src/schema/field-772-register.schema.json
+++ b/src/schema/field-772-register.schema.json
@@ -12,6 +12,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "0",
         "code": {
           "0": {
             "title": "Display note"
@@ -29,6 +30,7 @@
           "0",
           "8"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Parent"

--- a/src/schema/field-772-register.schema.json
+++ b/src/schema/field-772-register.schema.json
@@ -47,6 +47,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "t",
+            "x"
+          ],
           "properties": {
             "4": {
               "title": "Relationship",

--- a/src/schema/field-772-work.schema.json
+++ b/src/schema/field-772-work.schema.json
@@ -12,6 +12,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "0",
         "code": {
           "0": {
             "title": "Display note"
@@ -29,6 +30,7 @@
           "0",
           "8"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Parent"

--- a/src/schema/field-772-work.schema.json
+++ b/src/schema/field-772-work.schema.json
@@ -47,6 +47,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "t",
+            "x"
+          ],
           "properties": {
             "4": {
               "title": "Relationship",

--- a/src/schema/field-773.schema.json
+++ b/src/schema/field-773.schema.json
@@ -12,6 +12,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "0",
         "code": {
           "0": {
             "title": "Display note"
@@ -28,6 +29,7 @@
           "\\",
           "8"
         ],
+        "defaultValue": "\\",
         "code": {
           "8": {
             "title": "No display constant generated"

--- a/src/schema/field-773.schema.json
+++ b/src/schema/field-773.schema.json
@@ -43,6 +43,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "t",
+            "x"
+          ],
           "properties": {
             "3": {
               "title": "Materials specified",

--- a/src/schema/field-774.schema.json
+++ b/src/schema/field-774.schema.json
@@ -12,6 +12,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "0",
         "code": {
           "0": {
             "title": "Display note"
@@ -28,6 +29,7 @@
           "\\",
           "8"
         ],
+        "defaultValue": "\\",
         "code": {
           "8": {
             "title": "No display constant generated"

--- a/src/schema/field-774.schema.json
+++ b/src/schema/field-774.schema.json
@@ -43,6 +43,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "t",
+            "x"
+          ],
           "properties": {
             "4": {
               "title": "Relationship",

--- a/src/schema/field-775-register.schema.json
+++ b/src/schema/field-775-register.schema.json
@@ -12,6 +12,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "0",
         "code": {
           "0": {
             "title": "Display note"
@@ -28,6 +29,7 @@
           "\\",
           "8"
         ],
+        "defaultValue": "\\",
         "code": {
           "8": {
             "title": "No display constant generated"

--- a/src/schema/field-775-register.schema.json
+++ b/src/schema/field-775-register.schema.json
@@ -43,6 +43,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "t",
+            "x"
+          ],
           "properties": {
             "4": {
               "title": "Relationship",

--- a/src/schema/field-775-work.schema.json
+++ b/src/schema/field-775-work.schema.json
@@ -12,6 +12,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "0",
         "code": {
           "0": {
             "title": "Display note"
@@ -28,6 +29,7 @@
           "\\",
           "8"
         ],
+        "defaultValue": "\\",
         "code": {
           "8": {
             "title": "No display constant generated"

--- a/src/schema/field-775-work.schema.json
+++ b/src/schema/field-775-work.schema.json
@@ -43,6 +43,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "t",
+            "x"
+          ],
           "properties": {
             "4": {
               "title": "Relationship",

--- a/src/schema/field-776-register.schema.json
+++ b/src/schema/field-776-register.schema.json
@@ -12,6 +12,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "0",
         "code": {
           "0": {
             "title": "Display note"
@@ -28,6 +29,7 @@
           "\\",
           "8"
         ],
+        "defaultValue": "\\",
         "code": {
           "8": {
             "title": "No display constant generated"

--- a/src/schema/field-776-register.schema.json
+++ b/src/schema/field-776-register.schema.json
@@ -43,6 +43,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "t",
+            "x"
+          ],
           "properties": {
             "4": {
               "title": "Relationship",

--- a/src/schema/field-776-work.schema.json
+++ b/src/schema/field-776-work.schema.json
@@ -12,6 +12,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "0",
         "code": {
           "0": {
             "title": "Display note"
@@ -28,6 +29,7 @@
           "\\",
           "8"
         ],
+        "defaultValue": "\\",
         "code": {
           "8": {
             "title": "No display constant generated"

--- a/src/schema/field-776-work.schema.json
+++ b/src/schema/field-776-work.schema.json
@@ -43,6 +43,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "t",
+            "x"
+          ],
           "properties": {
             "4": {
               "title": "Relationship",

--- a/src/schema/field-777-register.schema.json
+++ b/src/schema/field-777-register.schema.json
@@ -12,6 +12,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "0",
         "code": {
           "0": {
             "title": "Display note"
@@ -28,6 +29,7 @@
           "\\",
           "8"
         ],
+        "defaultValue": "\\",
         "code": {
           "8": {
             "title": "No display constant generated"

--- a/src/schema/field-777-register.schema.json
+++ b/src/schema/field-777-register.schema.json
@@ -43,6 +43,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "t",
+            "x"
+          ],
           "properties": {
             "4": {
               "title": "Relationship",

--- a/src/schema/field-777-work.schema.json
+++ b/src/schema/field-777-work.schema.json
@@ -12,6 +12,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "0",
         "code": {
           "0": {
             "title": "Display note"
@@ -28,6 +29,7 @@
           "\\",
           "8"
         ],
+        "defaultValue": "\\",
         "code": {
           "8": {
             "title": "No display constant generated"

--- a/src/schema/field-777-work.schema.json
+++ b/src/schema/field-777-work.schema.json
@@ -43,6 +43,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "t",
+            "x"
+          ],
           "properties": {
             "4": {
               "title": "Relationship",

--- a/src/schema/field-780-register.schema.json
+++ b/src/schema/field-780-register.schema.json
@@ -12,6 +12,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "0",
         "code": {
           "0": {
             "title": "Display note"
@@ -34,6 +35,7 @@
           "6",
           "7"
         ],
+        "defaultValue": "0",
         "code": {
           "0": {
             "title": "Continues"

--- a/src/schema/field-780-register.schema.json
+++ b/src/schema/field-780-register.schema.json
@@ -67,6 +67,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "t",
+            "x"
+          ],
           "properties": {
             "4": {
               "title": "Relationship",

--- a/src/schema/field-780-work.schema.json
+++ b/src/schema/field-780-work.schema.json
@@ -12,6 +12,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "0",
         "code": {
           "0": {
             "title": "Display note"
@@ -34,6 +35,7 @@
           "6",
           "7"
         ],
+        "defaultValue": "0",
         "code": {
           "0": {
             "title": "Continues"

--- a/src/schema/field-780-work.schema.json
+++ b/src/schema/field-780-work.schema.json
@@ -67,6 +67,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "t",
+            "x"
+          ],
           "properties": {
             "4": {
               "title": "Relationship",

--- a/src/schema/field-785-register.schema.json
+++ b/src/schema/field-785-register.schema.json
@@ -71,6 +71,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "t",
+            "x"
+          ],
           "properties": {
             "4": {
               "title": "Relationship",

--- a/src/schema/field-785-register.schema.json
+++ b/src/schema/field-785-register.schema.json
@@ -12,6 +12,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "0",
         "code": {
           "0": {
             "title": "Display note"
@@ -35,6 +36,7 @@
           "7",
           "8"
         ],
+        "defaultValue": "0",
         "code": {
           "0": {
             "title": "Continued by"

--- a/src/schema/field-785-work.schema.json
+++ b/src/schema/field-785-work.schema.json
@@ -71,6 +71,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "t",
+            "x"
+          ],
           "properties": {
             "4": {
               "title": "Relationship",

--- a/src/schema/field-785-work.schema.json
+++ b/src/schema/field-785-work.schema.json
@@ -12,6 +12,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "0",
         "code": {
           "0": {
             "title": "Display note"
@@ -35,6 +36,7 @@
           "7",
           "8"
         ],
+        "defaultValue": "0",
         "code": {
           "0": {
             "title": "Continued by"

--- a/src/schema/field-786.schema.json
+++ b/src/schema/field-786.schema.json
@@ -12,6 +12,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "0",
         "code": {
           "0": {
             "title": "Display note"
@@ -28,6 +29,7 @@
           "\\",
           "8"
         ],
+        "defaultValue": "\\",
         "code": {
           "8": {
             "title": "No display constant generated"

--- a/src/schema/field-786.schema.json
+++ b/src/schema/field-786.schema.json
@@ -43,6 +43,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "t",
+            "x"
+          ],
           "properties": {
             "4": {
               "title": "Relationship",

--- a/src/schema/field-787-register.schema.json
+++ b/src/schema/field-787-register.schema.json
@@ -12,6 +12,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "0",
         "code": {
           "0": {
             "title": "Display note"
@@ -28,6 +29,7 @@
           "\\",
           "8"
         ],
+        "defaultValue": "\\",
         "code": {
           "8": {
             "title": "No display constant generated"

--- a/src/schema/field-787-register.schema.json
+++ b/src/schema/field-787-register.schema.json
@@ -43,6 +43,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "t",
+            "x"
+          ],
           "properties": {
             "4": {
               "title": "Relationship",

--- a/src/schema/field-787-work.schema.json
+++ b/src/schema/field-787-work.schema.json
@@ -12,6 +12,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "0",
         "code": {
           "0": {
             "title": "Display note"
@@ -28,6 +29,7 @@
           "\\",
           "8"
         ],
+        "defaultValue": "\\",
         "code": {
           "8": {
             "title": "No display constant generated"

--- a/src/schema/field-787-work.schema.json
+++ b/src/schema/field-787-work.schema.json
@@ -43,6 +43,10 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "t",
+            "x"
+          ],
           "properties": {
             "4": {
               "title": "Relationship",

--- a/src/schema/field-800.schema.json
+++ b/src/schema/field-800.schema.json
@@ -13,6 +13,7 @@
           "1",
           "3"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Forename"
@@ -29,6 +30,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-800.schema.json
+++ b/src/schema/field-800.schema.json
@@ -41,6 +41,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-810.schema.json
+++ b/src/schema/field-810.schema.json
@@ -41,6 +41,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-810.schema.json
+++ b/src/schema/field-810.schema.json
@@ -13,6 +13,7 @@
           "1",
           "2"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Inverted name"
@@ -29,6 +30,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-811.schema.json
+++ b/src/schema/field-811.schema.json
@@ -41,6 +41,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-811.schema.json
+++ b/src/schema/field-811.schema.json
@@ -13,6 +13,7 @@
           "1",
           "2"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Inverted name"
@@ -29,6 +30,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-830.schema.json
+++ b/src/schema/field-830.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Nonfiling characters",
         "type": "string",
         "const": "0",
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "9"

--- a/src/schema/field-830.schema.json
+++ b/src/schema/field-830.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-840.schema.json
+++ b/src/schema/field-840.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Nonfiling characters",
         "type": "string",
         "const": "0",
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "9"

--- a/src/schema/field-840.schema.json
+++ b/src/schema/field-840.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "a": {
               "title": "Title",

--- a/src/schema/field-850.schema.json
+++ b/src/schema/field-850.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-850.schema.json
+++ b/src/schema/field-850.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "8": {
               "title": "Field link and sequence number",

--- a/src/schema/field-851.schema.json
+++ b/src/schema/field-851.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "3": {
               "title": "Materials specified",

--- a/src/schema/field-851.schema.json
+++ b/src/schema/field-851.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-852.schema.json
+++ b/src/schema/field-852.schema.json
@@ -83,6 +83,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "2": {
               "title": "Source of classification or shelving scheme",

--- a/src/schema/field-852.schema.json
+++ b/src/schema/field-852.schema.json
@@ -20,6 +20,7 @@
           "7",
           "8"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Library of Congress classification"
@@ -62,6 +63,7 @@
           "1",
           "2"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Not enumeration"

--- a/src/schema/field-856.schema.json
+++ b/src/schema/field-856.schema.json
@@ -75,6 +75,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "u"
+          ],
           "properties": {
             "2": {
               "title": "Access method",

--- a/src/schema/field-856.schema.json
+++ b/src/schema/field-856.schema.json
@@ -17,6 +17,7 @@
           "4",
           "7"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Email"
@@ -51,6 +52,7 @@
           "2",
           "8"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Resource"

--- a/src/schema/field-880.schema.json
+++ b/src/schema/field-880.schema.json
@@ -17,6 +17,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "patternProperties": {
             "6": {
               "title": "Linkage",

--- a/src/schema/field-882.schema.json
+++ b/src/schema/field-882.schema.json
@@ -8,6 +8,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"
@@ -18,6 +19,7 @@
       "title": "Undefined",
       "type": "string",
       "const": "\\",
+      "defaultValue": "\\",
       "code": {
         "\\": {
           "title": "Undefined"

--- a/src/schema/field-882.schema.json
+++ b/src/schema/field-882.schema.json
@@ -30,6 +30,9 @@
       "type": "array",
       "items": {
         "type": "object",
+        "defaultProperties": [
+          "a"
+        ],
         "properties": {
           "6": {
             "title": "Linkage",

--- a/src/schema/field-883.schema.json
+++ b/src/schema/field-883.schema.json
@@ -41,6 +41,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-883.schema.json
+++ b/src/schema/field-883.schema.json
@@ -13,6 +13,7 @@
           "0",
           "1"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Fully machine"
@@ -29,6 +30,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-884.schema.json
+++ b/src/schema/field-884.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-884.schema.json
+++ b/src/schema/field-884.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "a": {
               "title": "Conversion process",

--- a/src/schema/field-885.schema.json
+++ b/src/schema/field-885.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "0": {
               "title": "Authority record control number or standard number",

--- a/src/schema/field-885.schema.json
+++ b/src/schema/field-885.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-886.schema.json
+++ b/src/schema/field-886.schema.json
@@ -13,6 +13,7 @@
           "1",
           "2"
         ],
+        "defaultValue": "\\",
         "code": {
           "0": {
             "title": "Leader"
@@ -29,6 +30,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-886.schema.json
+++ b/src/schema/field-886.schema.json
@@ -41,6 +41,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "2": {
               "title": "Source of data",

--- a/src/schema/field-887.schema.json
+++ b/src/schema/field-887.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "2": {
               "title": "Source of data",

--- a/src/schema/field-887.schema.json
+++ b/src/schema/field-887.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "const": "\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"

--- a/src/schema/field-950.schema.json
+++ b/src/schema/field-950.schema.json
@@ -31,6 +31,9 @@
         "type": "array",
         "items": {
           "type": "object",
+          "defaultProperties": [
+            "a"
+          ],
           "properties": {
             "a": {
               "title": "Internal note",

--- a/src/schema/field-950.schema.json
+++ b/src/schema/field-950.schema.json
@@ -9,6 +9,7 @@
         "title": "Undefined",
         "type": "string",
         "pattern": "[0-9]|\\\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"
@@ -19,6 +20,7 @@
         "title": "Undefined",
         "type": "string",
         "pattern": "[0-9]|\\\\",
+        "defaultValue": "\\",
         "code": {
           "\\": {
             "title": "Undefined"


### PR DESCRIPTION
Default subfields (`defaultProperties`) :

- 080 : $a $2
- 082 : $a $2
- 210 : $a $b
- 222 : $a $b
- 260 : $a $b $c
- 264 : $a $b $c
- 336,337,338 : $a $2
- 7XX : $t $x
- 856 : $u
- others : $a

Default indicators (`defaultCode`) :

- 024 :  8 blank
- 080 : 0 blank
- 210 : 1 blank
- 245 : 1 blank
- 246 : 3 3
- 264 : blank 1
- 650 : blank 4
- 7XX : 0 blank (except 780 et 785 : blank blank)
- 856 : 4 0
- others : blank blank