### PR TITLE
chg: Rollback additional properties

### DIFF
--- a/dist/himarc-register.schema.json
+++ b/dist/himarc-register.schema.json
@@ -42625,7 +42625,7 @@
           "isRepeatable": true
         }
       },
-      "additionalProperties": false,
+      "additionalProperties": true,
       "allOf": [
         {
           "required": [

--- a/dist/himarc-work.schema.json
+++ b/dist/himarc-work.schema.json
@@ -42582,7 +42582,7 @@
           "isRepeatable": true
         }
       },
-      "additionalProperties": false,
+      "additionalProperties": true,
       "allOf": [
         {
           "required": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "json-schema-himarc",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-schema-himarc",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "description": "JSON Schema for himarc ",
   "private": true,
   "main": "main.js",

--- a/src/schema/himarc-register.schema.json
+++ b/src/schema/himarc-register.schema.json
@@ -790,7 +790,7 @@
           "$ref": "field-950.schema.json"
         }
       },
-      "additionalProperties": false,
+      "additionalProperties": true,
       "allOf": [
         {
           "required": [

--- a/src/schema/himarc-work.schema.json
+++ b/src/schema/himarc-work.schema.json
@@ -790,7 +790,7 @@
           "$ref": "field-950.schema.json"
         }
       },
-      "additionalProperties": false,
+      "additionalProperties": true,
       "allOf": [
         {
           "required": [


### PR DESCRIPTION
We need specs for fields `039` & `699` before setting `additionalProperties` to `false`